### PR TITLE
Fix php 7.3 compat issue

### DIFF
--- a/library/Zend/View/Helper/HeadLink.php
+++ b/library/Zend/View/Helper/HeadLink.php
@@ -373,6 +373,7 @@ class Zend_View_Helper_HeadLink extends Zend_View_Helper_Placeholder_Container_S
         $type                  = 'text/css';
         $media                 = 'screen';
         $conditionalStylesheet = false;
+        $extras                = array();
         $href                  = array_shift($args);
 
         if ($this->_isDuplicateStylesheet($href)) {


### PR DESCRIPTION
This makes the zend-view package run on PHP 7.3.

See https://github.com/LibreTime/libretime/pull/670#issuecomment-453925949 for where this was reported.

PHP has this in their [docs](http://php.net/manual/en/function.compact.php) on compat.

> Before PHP 7.3, any strings that are not set will silently be skipped.

I'm hoping that there isn't more 7.3 compat stuff lurking but will fix it if I find more.

I'm using `array()` instead of `[]` so I don't break old PHP 5.x stuff.